### PR TITLE
Use a DOMString for encryption scheme. Addresses #8.

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -28,10 +28,19 @@ specify which encryption schemes it could use.
 ## Web IDL
 
 ```js
-enum MediaKeyEncryptionScheme { "cenc", "cbcs" };
+dictionary MediaKeySystemMediaCapability {
+    DOMString contentType = "";
+    DOMString robustness = "";
+    DOMString? encryptionScheme = null;
+};
 ```
 
-The MediaKeyEncryptionScheme enumeration is defined as follows:
+`encryptionScheme` of type `DOMString`, defaulting to `null`
+
+The encryption scheme used by the content.  A missing or `null` value indicates
+that any encryption scheme is acceptable.
+
+Expected non-`null` values for encryptionScheme are:
  - *cenc*: The 'cenc' mode, defined in [ISO 23001-7:2016][], section 4.2a.
            AES-CTR mode full sample and video NAL subsample encryption.
  - *cbcs*: The 'cbcs' mode, defined in [ISO 23001-7:2016][], section 4.2d.
@@ -44,23 +53,9 @@ to and compatible with the 'cenc' encryption mode defined in
 [ISO 23001-7:2016]: https://www.iso.org/standard/68042.html
 [WebM Encryption]: https://www.webmproject.org/docs/webm-encryption/
 
-
-```js
-dictionary MediaKeySystemMediaCapability {
-    DOMString contentType = "";
-    DOMString robustness = "";
-    MediaKeyEncryptionScheme? encryptionScheme = null;
-};
-```
-
-`encryptionScheme` of type `MediaKeyEncryptionScheme`, defaulting to `null`
-
-The encryption scheme used by the content.  A missing or `null` value indicates
-that any encryption scheme is acceptable.
-
 In the [Get Supported Capabilities for Audio/Video Type][] algorithm,
-implementations **must** skip capabilities specifying unsupported encryption
-schemes.
+implementations **must** skip capabilities specifying unsupported or
+unrecognized encryption schemes.
 
 If `encryptionScheme` from the application is `null` or missing, the
 `encryptionScheme` fields in the returned configuration **must** be `null`.


### PR DESCRIPTION
Using a DOMString instead of an enum for the encryptionScheme member
allows for safer extension of encryption schemes. Without using a
DOMString, invalid enum values will result in a TypeError.

An example of why this is problematic: if a new encryption scheme, fooo,
is added, and an application checks for support using the API, an older
User Agent may throw a TypeError as fooo is not a valid enum value.
Using a DOMString avoids this, and User Agents can treat configurations
with unrecognized schemes as unsupported. This allows the call to
requestMediaKeySystemAccess() to succeed, provided other configurations
with supported schemes are provided.